### PR TITLE
remove whitspace that causes error

### DIFF
--- a/templates/env/netbox.env.j2
+++ b/templates/env/netbox.env.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 
-ALLOWED_HOSTS = {{ netbox_allowed_hosts }}
+ALLOWED_HOSTS={{ netbox_allowed_hosts }}
 CORS_ORIGIN_ALLOW_ALL={{ netbox_cors_origin_allow_all }}
 CORS_ORIGIN_ALLOW_ALL=True
 CORS_ORIGIN_WHITELIST={{ netbox_cors_origin_whitelist }}


### PR DESCRIPTION
Error caused by this:

```
fatal: [xxx]: FAILED! => {"changed": false, "msg": "Configuration error - In file /opt/netbox/env/netbox.env: environment variable name 'ALLOWED_HOSTS ' may not contain whitespace."
```

Signed-off-by: Felix Kronlage-Dammers <fkr@hazardous.org>