### PR TITLE
Change hardcoded dir in handler to the base_dir var

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,4 +2,4 @@
 - name: Restart netbox
   shell:
     cmd: "docker compose up -d"
-    chdir: "/opt/netbox"
+    chdir: "{{ netbox_base_dir }}"


### PR DESCRIPTION
I tried setting the base_dir to something other than opt and "restart netbox" failed because it was hardcoded. 