### PR TITLE
Add support for caddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,64 +32,96 @@ And finally, install the role with Ansible Galaxy:
 
 Configuration and installation options are made available as variables. Some of these (`secret_key`, passwords) _must_ be overridden before use!
 
-| Option                                         | Default                       | Description                                                                                                                                             |
-| ---------------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `netbox_base_dir`                              | `/opt/netbox`                 | Root path for netbox's docker-compose file and data store                                                                                               |
-| `netbox_port`                                  | `8080`                        | Host port to expose netbox on. If blank, netbox's port is not exposed                                                                                   |
-| `netbox_netbox_image`                          | `docker.io/netboxcommunity/netbox:v4.1-3.0.1` | Netbox docker image tag                                                                                                                 |
-| `netbox_valkey_image`                          | `docker.io/valkey/valkey:8.0-alpine`              | Valkey docker image tag                                                                                                             |
-| `netbox_postgres_image`                        | `docker.io/postgres:16-alpine`          | Postgres docker image tag                                                                                                                     |
-| `netbox_admin_api_token`                       | -                             | API token for the default admin user, created on first run                                                                                              |
-| `netbox_admin_email`                           | `admin@example.com`           | Email of the default admin user, created on first run                                                                                                   |
-| `netbox_admin_password`                        | `admin`                       | Password for the default admin user, created on first run                                                                                               |
-| `netbox_admin_username`                        | `admin`                       | Username of the default admin user, created on first run                                                                                                |
-| `netbox_allowed_hosts`                         | `*`                           | If set, connections will be restricted to this host header                                                                                              |
-| `netbox_cors_origin_allow_all`                 | `true`                        | If set to true, all CORS origins will be allowed                                                                                                        |
-| `netbox_cors_origin_whitelist`                 | `http://localhost`            | Whitelist of acceptable CORS origin headers                                                                                                             |
-| `netbox_default_page_size`                     | `250`                         | Default number of objects for paginated views                                                                                                           |
-| `netbox_email_certfile`                        | -                             | [Email server settings documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-EMAIL_HOST)                                       |
-| `netbox_email_from`                            | `netbox@bar.com`              | [Email server settings documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-EMAIL_HOST)                                       |
-| `netbox_email_keyfile`                         | -                             | [Email server settings documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-EMAIL_HOST)                                       |
-| `netbox_email_password`                        | -                             | [Email server settings documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-EMAIL_HOST)                                       |
-| `netbox_email_port`                            | `25`                          | [Email server settings documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-EMAIL_HOST)                                       |
-| `netbox_email_server`                          | `localhost`                   | [Email server settings documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-EMAIL_HOST)                                       |
-| `netbox_email_timeout`                         | `5`                           | [Email server settings documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-EMAIL_HOST)                                       |
-| `netbox_email_use_ssl`                         | `false`                       | [Email server settings documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-EMAIL_HOST)                                       |
-| `netbox_email_use_tls`                         | `false`                       | [Email server settings documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-EMAIL_HOST)                                       |
-| `netbox_email_username`                        | `netbox`                      | [Email server settings documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-EMAIL_HOST)                                       |
-| `netbox_enforce_global_unique`                 | `false`                       | Enforcement of unique IP space can be toggled on a per-VRF basis. To enforce unique IP space within the global table, set this to true                  |
-| `netbox_graphql_enabled`                       | `true`                        | Enable GraphQL API                                                                                                                                      |
-| `netbox_housekeeping_interval`                 | `86400`                       | Interval to run housekeeping worker                                                                                                                     |
-| `netbox_container_labels`                      | `[]`                          | Optional extra container labels to apply to the netbox container. See [Traefiknginx-proxy Support](#traefiknginx-proxy-support)                         |
-| `netbox_container_env`                         | `[]`                          | Optional extra container environment variables to apply to the netbox container. See [Traefik/nginx-proxy Support](#traefiknginx-proxy-support)         |
-| `netbox_login_required`                        | `false`                       | Whether or not a user must be authenticated to view DCIM details in Netbox                                                                              |
-| `netbox_max_page_size`                         | `1000`                        | Maximum number of objects for paginated API requests                                                                                                    |
-| `netbox_metrics_enabled`                       | `false`                       | Expose Prometheus monitoring metrics at the HTTP endpoint '/metrics'                                                                                    |
-| `netbox_pg_db`                                 | `netbox`                      | Postgres database name                                                                                                                                  |
-| `netbox_pg_host`                               | `postgres`                    | Postgres database host. This should not be changed if using the default docker-compose setup.                                                           |
-| `netbox_pg_password`                           | `RANDOM_SEED`            | Postgres password                                                                                                                                            |
-| `netbox_pg_user`                               | `netbox`                      | Postgres user                                                                                                                                           |
-| `netbox_additional_network_names`              | -                             | Extra external networks to attach to the netbox container. See [Traefik/nginx-proxy Support](#traefiknginx-proxy-support)                               |
-| `netbox_valkey_cache_host`                     | `valkey-cache`                 | Valkey cache instance host. This should not be changed if using the default docker-compose setup.                                                      |
-| `netbox_valkey_cache_insecure_skip_tls_verify` | `false`                       | If true, certificates for valkey cache are not checked                                                                                                  |
-| `netbox_valkey_cache_password`                 | `RANDOM_SEED`               | Valkey cache instance password                                                                                                                            |
-| `netbox_valkey_cache_ssl`                      | `false`                       | If true, communication with valkey is secured with SSL                                                                                                  |
-| `netbox_valkey_host`                           | `valkey`                       | Valkey instance host. This should not be changed if using the default docker-compose setup.                                                            |
-| `netbox_valkey_insecure_skip_tls_verify`       | `false`                       | If true, certificates for valkey are not checked                                                                                                        |
-| `netbox_valkey_password`                       | `RANDOM_SEED`               | Valkey instance password                                                                                                                                  |
-| `netbox_secret_key`                            | -                             | [Netbox secret key](https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-SECRET_KEY). Should be at least 50 characters long               |
-| `netbox_skip_startup_scripts`                  | `false`                       | If true, do not run startup scripts on container start                                                                                                  |
-| `netbox_skip_superuser`                        | `false`                       | If true, do not create superuser on container start                                                                                                     |
-| `netbox_webhooks_enabled`                      | `true`                        | If true, enable netbox webhooks functionality                                                                                                           |
-| `netbox_extra_config`                          | -                             | If provided, this string will be rendered in [`config/extra.py`](https://github.com/netbox-community/netbox-docker/blob/release/configuration/extra.py) |
+| Option                                         | Default                                       | Description                                                                                                                                             |
+| ---------------------------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `netbox_base_dir`                              | `/opt/netbox`                                 | Root path for netbox's docker-compose file and data store                                                                                               |
+| `netbox_port`                                  | `8080`                                        | Host port to expose netbox on. If blank, netbox's port is not exposed                                                                                   |
+| `netbox_netbox_image`                          | `docker.io/netboxcommunity/netbox:v4.1-3.0.1` | Netbox docker image tag                                                                                                                                 |
+| `netbox_valkey_image`                          | `docker.io/valkey/valkey:8.0-alpine`          | Valkey docker image tag                                                                                                                                 |
+| `netbox_postgres_image`                        | `docker.io/postgres:16-alpine`                | Postgres docker image tag                                                                                                                               |
+| `netbox_caddy_image`                           | `docker.io/caddy:2-alpine`                    | Caddy docker image tag                                                                                                                                  |
+| `netbox_admin_api_token`                       | -                                             | API token for the default admin user, created on first run                                                                                              |
+| `netbox_admin_email`                           | `admin@example.com`                           | Email of the default admin user, created on first run                                                                                                   |
+| `netbox_admin_password`                        | `admin`                                       | Password for the default admin user, created on first run                                                                                               |
+| `netbox_admin_username`                        | `admin`                                       | Username of the default admin user, created on first run                                                                                                |
+| `netbox_allowed_hosts`                         | `*`                                           | If set, connections will be restricted to this list host names (also used in caddy)                                                                     |
+| `netbox_cors_origin_allow_all`                 | `true`                                        | If set to true, all CORS origins will be allowed                                                                                                        |
+| `netbox_cors_origin_whitelist`                 | `http://localhost`                            | Whitelist of acceptable CORS origin headers                                                                                                             |
+| `netbox_default_page_size`                     | `250`                                         | Default number of objects for paginated views                                                                                                           |
+| `netbox_email_certfile`                        | -                                             | [Email server settings documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-EMAIL_HOST)                                       |
+| `netbox_email_from`                            | `netbox@bar.com`                              | [Email server settings documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-EMAIL_HOST)                                       |
+| `netbox_email_keyfile`                         | -                                             | [Email server settings documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-EMAIL_HOST)                                       |
+| `netbox_email_password`                        | -                                             | [Email server settings documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-EMAIL_HOST)                                       |
+| `netbox_email_port`                            | `25`                                          | [Email server settings documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-EMAIL_HOST)                                       |
+| `netbox_email_server`                          | `localhost`                                   | [Email server settings documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-EMAIL_HOST)                                       |
+| `netbox_email_timeout`                         | `5`                                           | [Email server settings documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-EMAIL_HOST)                                       |
+| `netbox_email_use_ssl`                         | `false`                                       | [Email server settings documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-EMAIL_HOST)                                       |
+| `netbox_email_use_tls`                         | `false`                                       | [Email server settings documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-EMAIL_HOST)                                       |
+| `netbox_email_username`                        | `netbox`                                      | [Email server settings documentation](https://docs.djangoproject.com/en/3.1/ref/settings/#std:setting-EMAIL_HOST)                                       |
+| `netbox_enforce_global_unique`                 | `false`                                       | Enforcement of unique IP space can be toggled on a per-VRF basis. To enforce unique IP space within the global table, set this to true                  |
+| `netbox_graphql_enabled`                       | `true`                                        | Enable GraphQL API                                                                                                                                      |
+| `netbox_housekeeping_interval`                 | `86400`                                       | Interval to run housekeeping worker                                                                                                                     |
+| `netbox_container_labels`                      | `[]`                                          | Optional extra container labels to apply to the netbox container. See [Traefiknginx-proxy Support](#traefiknginx-proxy-support)                         |
+| `netbox_container_env`                         | `[]`                                          | Optional extra container environment variables to apply to the netbox container. See [Traefik/nginx-proxy Support](#traefiknginx-proxy-support)         |
+| `netbox_login_required`                        | `false`                                       | Whether or not a user must be authenticated to view DCIM details in Netbox                                                                              |
+| `netbox_max_page_size`                         | `1000`                                        | Maximum number of objects for paginated API requests                                                                                                    |
+| `netbox_metrics_enabled`                       | `false`                                       | Expose Prometheus monitoring metrics at the HTTP endpoint '/metrics'                                                                                    |
+| `netbox_pg_db`                                 | `netbox`                                      | Postgres database name                                                                                                                                  |
+| `netbox_pg_host`                               | `postgres`                                    | Postgres database host. This should not be changed if using the default docker-compose setup.                                                           |
+| `netbox_pg_password`                           | `RANDOM_SEED`                                 | Postgres password                                                                                                                                       |
+| `netbox_pg_user`                               | `netbox`                                      | Postgres user                                                                                                                                           |
+| `netbox_additional_network_names`              | -                                             | Extra external networks to attach to the netbox container. See [Traefik/nginx-proxy Support](#traefiknginx-proxy-support)                               |
+| `netbox_valkey_cache_host`                     | `valkey-cache`                                | Valkey cache instance host. This should not be changed if using the default docker-compose setup.                                                       |
+| `netbox_valkey_cache_insecure_skip_tls_verify` | `false`                                       | If true, certificates for valkey cache are not checked                                                                                                  |
+| `netbox_valkey_cache_password`                 | `RANDOM_SEED`                                 | Valkey cache instance password                                                                                                                          |
+| `netbox_valkey_cache_ssl`                      | `false`                                       | If true, communication with valkey is secured with SSL                                                                                                  |
+| `netbox_valkey_host`                           | `valkey`                                      | Valkey instance host. This should not be changed if using the default docker-compose setup.                                                             |
+| `netbox_valkey_insecure_skip_tls_verify`       | `false`                                       | If true, certificates for valkey are not checked                                                                                                        |
+| `netbox_valkey_password`                       | `RANDOM_SEED`                                 | Valkey instance password                                                                                                                                |
+| `netbox_secret_key`                            | `RANDOM_SEED`                                 | [Netbox secret key](https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-SECRET_KEY). Should be at least 50 characters long               |
+| `netbox_skip_startup_scripts`                  | `false`                                       | If true, do not run startup scripts on container start                                                                                                  |
+| `netbox_skip_superuser`                        | `false`                                       | If true, do not create superuser on container start                                                                                                     |
+| `netbox_webhooks_enabled`                      | `true`                                        | If true, enable netbox webhooks functionality                                                                                                           |
+| `netbox_use_caddy`                             | `false`                                       | If set, Caddy will be used to serve Netbox over TLS                                                                                                     |
+| `netbox_caddy_letsencrypt_email`               | -                                             | Email address to use for letsencrypt automatic certificate generation                                                                                   |
+| `netbox_caddy_http_port`                       | `80`                                          | Caddy HTTP port                                                                                                                                         |
+| `netbox_caddy_https_port`                      | `443`                                         | Caddy HTTPS port                                                                                                                                        |
+| `netbox_ssl_cert_bundle`                       | -                                             | Caddy certificate bundle                                                                                                                                |
+| `netbox_ssl_cert_key`                          | -                                             | Caddy certificate key                                                                                                                                   |
+| `netbox_extra_config`                          | -                                             | If provided, this string will be rendered in [`config/extra.py`](https://github.com/netbox-community/netbox-docker/blob/release/configuration/extra.py) |
 
 ## Example Playbook
 
 Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
 
+```yaml
     - hosts: servers
       roles:
         - netbox-docker
+```
+
+## TLS for localhost
+Developing locally and testing TLS (i.e. https) features often poses a challenge. This guide is intended for people developing with, on or for NetBox or NetBox Docker on their computer. It allows to access NetBox Docker through TLS on https://localhost:443, https://127.0.0.1:443 and https://[::1]:443. It is based on the setup recommended by the [Netbox-Docker wiki on TLS](https://github.com/netbox-community/netbox-docker/wiki/TLS#tls-for-localhost).
+First install `mkcert` on your computer. It creates and installs a local CA-Certificate, which will be used by mkcert to create and sign other certificates. This way, your certificates are trusted on your own computer and you don't get a TLS warning in your tools (browsers, cURL, and so forth).
+
+Begin by creating the certificates for localhost and it's IPv4 and IPv6 addresses using the following commands.
+
+```shell
+mkcert -install
+mkcert localhost 127.0.0.1 ::1
+```
+This should have created a file called `localhost+2.pem` and another file called `localhost+2-key.pem`. Use these two certificates with a slight modification of the setup proposed above:
+
+```yaml
+    - hosts: localhost
+      vars:
+        netbox_port: null
+        netbox_use_caddy: true
+        netbox_ssl_cert_bundle: path_to/localhost+2.pem
+        netbox_ssl_cert_key: path_to/localhost+2-key.pem
+      roles:
+        - netbox-docker
+```
 
 ## Traefik/nginx-proxy Support
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,14 @@ netbox_netbox_version: 4.1
 netbox_netbox_image: "docker.io/netboxcommunity/netbox:v{{ netbox_netbox_version }}-{{ netbox_netbox_docker_version }}"
 netbox_valkey_image: docker.io/valkey/valkey:8.0-alpine
 netbox_postgres_image: docker.io/postgres:16-alpine
+netbox_caddy_image: docker.io/caddy:2-alpine
+
+netbox_use_caddy: false
+netbox_caddy_letsencrypt_email: ""
+netbox_caddy_http_port: 80
+netbox_caddy_https_port: 443
+netbox_ssl_cert_bundle: ""
+netbox_ssl_cert_key: ""
 
 netbox_admin_api_token: ""
 netbox_admin_email: admin@example.com

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,7 @@
   loop:
     - docker-compose.yml
     - extra.py
+    - Caddyfile
   notify: Restart netbox
 
 - name: Update container mounts

--- a/templates/Caddyfile.j2
+++ b/templates/Caddyfile.j2
@@ -1,0 +1,19 @@
+{{ ansible_managed | comment }}
+# https://github.com/netbox-community/netbox-docker/wiki/TLS
+
+{% if netbox_caddy_letsencrypt_email %}{
+    # Email to use on Let's Encrypt
+    email {{ netbox_caddy_letsencrypt_email }}
+}{% endif %}
+
+{{ netbox_allowed_hosts | join(", ") }} {
+    reverse_proxy netbox:8080
+    encode gzip zstd
+
+{% if netbox_ssl_cert_bundle %}
+    tls /etc/ssl/private/cert.crt /etc/ssl/private/key.key
+{% endif %}
+    log {
+        level error
+    }
+}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -3,6 +3,47 @@
 # Source: https://github.com/netbox-community/netbox-docker/blob/release/docker-compose.yml
 
 services:
+{% if netbox_use_caddy and (netbox_ssl_cert_bundle or netbox_caddy_letsencrypt_email) %}
+  # caddy container for TLS termination
+  tls:
+    image: {{netbox_caddy_image}}
+    restart: unless-stopped
+    depends_on:
+      netbox:
+        condition: service_healthy
+    volumes:
+    - type: bind
+      source: /etc/timezone
+      target: /etc/timezone
+      read_only: true
+    - type: bind
+      source: /etc/localtime
+      target: /etc/localtime
+      read_only: true
+    - type: bind
+      source: ./Caddyfile
+      target: "/etc/caddy/Caddyfile"
+      read_only: true
+{% if netbox_ssl_cert_bundle %}
+    - type: bind
+      source: "{{netbox_ssl_cert_bundle}}"
+      target: "/etc/ssl/private/cert.crt"
+      read_only: true
+    - type: bind
+      source: "{{netbox_ssl_cert_key}}"
+      target: "/etc/ssl/private/key.key"
+      read_only: true
+{% endif %}
+    - type: volume
+      source: netbox-caddy-data
+      target: /data
+    - type: volume
+      source: netbox-caddy-config
+      target: /config
+    ports:
+    - "{{netbox_caddy_http_port}}:80" # Allows for http redirection
+    - "{{netbox_caddy_https_port}}:443"
+{% endif %}
   netbox: &netbox
     image: {{ netbox_netbox_image }}
     depends_on:
@@ -128,6 +169,10 @@ volumes:
     driver: local
   netbox-valkey-data:
     driver: local
+{% if netbox_use_caddy %}
+  netbox-caddy-data:
+  netbox-caddy-config:
+{% endif %}
 
 {% if netbox_additional_network_names %}
 networks:


### PR DESCRIPTION
Fixes #18 

Based on [netbox-docker wiki](https://github.com/netbox-community/netbox-docker/wiki/TLS), this adds "built in" TLS termination in the docker-compose file using Caddy.