### PR TITLE
Use better seeds for ansible.builtin.password

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,20 +37,20 @@ netbox_metrics_enabled: false
 netbox_pg_db: netbox
 netbox_pg_host: postgres
 netbox_pg_password: >
- "{{ lookup('ansible.builtin.password', '/tmp/netbox_pg_password.txt', chars=['ascii_letters'], length=16, seed=inventory_hostname) }}"
+ "{{ lookup('ansible.builtin.password', '/tmp/netbox_pg_password.txt', chars=['ascii_letters'], length=16, seed=inventory_hostname+'.netbox_pg_password') }}"
 netbox_pg_user: netbox
 netbox_additional_network_names: ""
 netbox_valkey_cache_host: valkey-cache
 netbox_valkey_cache_insecure_skip_tls_verify: false
 netbox_valkey_cache_password: >
- "{{ lookup('ansible.builtin.password', '/tmp/netbox_valkey_password.txt', chars=['ascii_letters'], length=16, seed=inventory_hostname) }}"
+ "{{ lookup('ansible.builtin.password', '/tmp/netbox_valkey_cache_password.txt', chars=['ascii_letters'], length=16, seed=inventory_hostname+'.netbox_valkey_cache_password') }}"
 netbox_valkey_cache_ssl: false
 netbox_valkey_host: valkey
 netbox_valkey_insecure_skip_tls_verify: false
 netbox_valkey_password: >
- "{{ lookup('ansible.builtin.password', '/tmp/netbox_valkey_password.txt', chars=['ascii_letters'], length=16, seed=inventory_hostname) }}"
+ "{{ lookup('ansible.builtin.password', '/tmp/netbox_valkey_password.txt', chars=['ascii_letters'], length=16, seed=inventory_hostname+'.netbox_valkey_password') }}"
 netbox_secret_key: >
- "{{ lookup('ansible.builtin.password', '/tmp/netbox_secret_key.txt', chars=['ascii_letters'], length=50, seed=inventory_hostname) }}"
+ "{{ lookup('ansible.builtin.password', '/tmp/netbox_secret_key.txt', chars=['ascii_letters'], length=50, seed=inventory_hostname+'.netbox_secret_key') }}"
 netbox_skip_startup_scripts: false
 netbox_skip_superuser: false
 netbox_webhooks_enabled: true


### PR DESCRIPTION
In #17 I replaced static defaults for passwords to use ansible's `ansible.builtin.password`. Unfortunately as the seed is currently using `inventory_hostname` for all passwords, they end up being all the same.

This PR aims to fix that.

